### PR TITLE
Change `prepublish` script to `prepare` (deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint ./src --ext .js,.jsx,.ts,.tsx",
     "build": "rollup -c",
-    "prepublish": "yarn run build",
+    "prepare": "yarn run build",
     "test": "yarn"
   },
   "peerDependencies": {


### PR DESCRIPTION
The script `prepublish` has been deprecated in favor of `prepare` ([reference](https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish)).