### PR TITLE
2.0.3 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "react-onesignal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "React OneSignal Module: Make it easy to integrate OneSignal with your React App!",
   "author": "rgomezp",
-  "contributors": [{ "name": "Rodrigo Gomez-Palacio" }, { "name": "Pedro Bini" }],
+  "contributors": [{ "name": "Rodrigo Gomez-Palacio" }, { "name": "Pedro Bini" }, { "name": "Graham Marlow" }],
   "homepage": "https://onesignal.com",
   "repository": "https://github.com/OneSignal/react-onesignal.git",
   "license": "MIT",
@@ -76,4 +76,3 @@
     "react"
   ]
 }
-

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,4 +35,3 @@ export default {
     commonjs(),
   ],
 };
-


### PR DESCRIPTION
Switch from a timeout strategy to script#onload and script#onerror so
that calls to #init will always resolve. This is important for consumers
of the react-onesignal package who want to call multiple functions
synchronously, for example:

```js
const doThingsInOrder = async () => {
  await OneSignal.init({ ... });
  await OneSignal.showSlidedownPrompt();
};
```

Without this change, those calls will hang indefinitely if adblock
prevents executing the web SDK from the cdn.onesignal.com domain.

An additional flag, `isOneSignalScriptFailed` is kept around to resolve
OneSignal SDK methods in the event of a CDN load failure. Since
resolutions in the queue are only called on `#init`, if SDK methods are
called after `#init` has already failed they will never resolve.

---

Also includes other minor miscellaneous nits and improvements.