### PR TITLE
Reject promise returned from init if script loading fails

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,12 +34,12 @@ const handleOnLoad = (resolve: () => void, options: IInitObject) => {
   });
 }
 
-const handleOnError = (resolve: () => void) => {
+const handleOnError = (reject: () => void) => {
   isOneSignalScriptFailed = true;
   // Ensure that any unresolved functions are cleared from the queue,
   // even in the event of a CDN load failure.
   processQueuedOneSignalFunctions();
-  resolve();
+  reject();
 }
 
 const processQueuedOneSignalFunctions = () => {
@@ -56,7 +56,7 @@ const processQueuedOneSignalFunctions = () => {
   });
 }
 
-const init = (options: IInitObject) => new Promise<void>(resolve => {
+const init = (options: IInitObject) => new Promise<void>((resolve, reject) => {
   if (isOneSignalInitialized) {
     resolve();
     return;
@@ -79,10 +79,10 @@ const init = (options: IInitObject) => new Promise<void>(resolve => {
     handleOnLoad(resolve, options);
   };
 
-  // Always resolve whether or not the script is successfully initialized.
-  // This is important for users who may block cdn.onesignal.com w/ adblock.
+  // Reject promise when the script is not successfully initialized.
+  // This is important for users who may block cdn.onesignal.com w/ adblock and want to understand if init was actually successful or not
   script.onerror = () => {
-    handleOnError(resolve);
+    handleOnError(reject);
   }
 
   document.head.appendChild(script);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-onesignal",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "React OneSignal Module: Make it easy to integrate OneSignal with your React App!",
   "author": "rgomezp",
   "contributors": [{ "name": "Rodrigo Gomez-Palacio" }, { "name": "Pedro Bini" }, { "name": "Graham Marlow" }],


### PR DESCRIPTION
Firstly, semantically doesn't make much sense to `resolve` a promise which obviously failed.  

Apart from that, we're handling the logic for when the user has AdBlock turned on, where we show a popup asking the user to disable the AdBlock in able to receive push notifications (which I suspect most developers would do), rejecting the promise returned from init removes the need for workarounds while still keeping the functionality untouched for other cases.