### PR TITLE
Fix missing reject for init

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -100,12 +100,12 @@ const init = (options: IInitObject): Promise<void> => {
     return Promise.reject(`Document is not defined.`);
   }
 
-  return new Promise<void>((resolve) => {
+  return new Promise<void>((resolve, reject) => {
     window.OneSignalDeferred?.push((OneSignal) => {
       OneSignal.init(options).then(() => {
         isOneSignalInitialized = true;
         resolve();
-      });
+      }).catch(reject);
     });
   });
 };


### PR DESCRIPTION
When I init the oneSignal sdk with some invalid config, I get the following error: 

```ts
try {
    await OneSignal.init({ appId: "example app id" });
} catch(e) {
    console.log("error with init")
}
```

```
Uncaught (in promise) Error: OneSignalSDK: HTTP sites are no longer supported starting with version 16 (User Model), your public site must start with https://. Please visit the OneSignal dashboard's Settings > Web Configuration to find this option.
```

This is an example error. The main issue is that the error is uncaught.

This PR will fix the uncaught exception