### PR TITLE
Provide types for external use

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -110,16 +110,17 @@ const init = (options: IInitObject): Promise<void> => {
   });
 };
 
-interface AutoPromptOptions { force?: boolean; forceSlidedownOverNative?: boolean; slidedownPromptOptions?: IOneSignalAutoPromptOptions; }
-interface IOneSignalAutoPromptOptions { force?: boolean; forceSlidedownOverNative?: boolean; isInUpdateMode?: boolean; categoryOptions?: IOneSignalCategories; }
-interface IOneSignalCategories { positiveUpdateButton: string; negativeUpdateButton: string; savingButtonText: string; errorButtonText: string; updateMessage: string; tags: IOneSignalTagCategory[]; }
-interface IOneSignalTagCategory { tag: string; label: string; checked?: boolean; }
-type PushSubscriptionNamespaceProperties = { id: string | null | undefined; token: string | null | undefined; optedIn: boolean; };
-type SubscriptionChangeEvent = { previous: PushSubscriptionNamespaceProperties; current: PushSubscriptionNamespaceProperties; };
-type NotificationEventName = 'click' | 'foregroundWillDisplay' | 'dismiss' | 'permissionChange' | 'permissionPromptDisplay';
+export interface AutoPromptOptions { force?: boolean; forceSlidedownOverNative?: boolean; slidedownPromptOptions?: IOneSignalAutoPromptOptions; }
+export interface IOneSignalAutoPromptOptions { force?: boolean; forceSlidedownOverNative?: boolean; isInUpdateMode?: boolean; categoryOptions?: IOneSignalCategories; }
+export interface IOneSignalCategories { positiveUpdateButton: string; negativeUpdateButton: string; savingButtonText: string; errorButtonText: string; updateMessage: string; tags: IOneSignalTagCategory[]; }
+export interface IOneSignalTagCategory { tag: string; label: string; checked?: boolean; }
+export type PushSubscriptionNamespaceProperties = { id: string | null | undefined; token: string | null | undefined; optedIn: boolean; };
+export type SubscriptionChangeEvent = { previous: PushSubscriptionNamespaceProperties; current: PushSubscriptionNamespaceProperties; };
+export type NotificationEventName = 'click' | 'foregroundWillDisplay' | 'dismiss' | 'permissionChange' | 'permissionPromptDisplay';
 type SlidedownEventName = 'slidedownShown';
-type OneSignalDeferredLoadedCallback = (onesignal: IOneSignalOneSignal) => void;
-interface IOSNotification {
+export type OneSignalDeferredLoadedCallback = (onesignal: IOneSignalOneSignal) => void;
+
+export interface IOSNotification {
   /**
    * The OneSignal notification id;
    *  - Primary id on OneSignal's REST API and dashboard
@@ -181,7 +182,7 @@ interface IOSNotification {
   readonly confirmDelivery: boolean;
 }
 
-interface IOSNotificationActionButton {
+export interface IOSNotificationActionButton {
   /**
    * Any unique identifier to represent which button was clicked. This is typically passed back to the service worker
    * and host page through events to identify which button was clicked.
@@ -202,7 +203,7 @@ interface IOSNotificationActionButton {
   readonly launchURL?: string;
 }
 
-interface NotificationClickResult {
+export interface NotificationClickResult {
   readonly actionId?: string;
   readonly url?: string;
 }
@@ -215,22 +216,22 @@ type NotificationEventTypeMap = {
   'permissionPromptDisplay': void;
 }
 
-interface NotificationForegroundWillDisplayEvent {
+export interface NotificationForegroundWillDisplayEvent {
   readonly notification: IOSNotification;
   preventDefault(): void;
 }
 
-interface NotificationDismissEvent {
+export interface NotificationDismissEvent {
   notification: IOSNotification;
 }
 
-interface NotificationClickEvent {
+export interface NotificationClickEvent {
   readonly notification: IOSNotification;
   readonly result: NotificationClickResult;
 }
 
 
-interface IInitObject {
+export interface IInitObject {
   appId: string;
   subdomainName?: string;
   requiresUserPrivacyConsent?: boolean;
@@ -251,7 +252,7 @@ interface IInitObject {
   [key: string]: any;
 }
 
-interface IOneSignalOneSignal {
+export interface IOneSignalOneSignal {
 	Slidedown: IOneSignalSlidedown;
 	Notifications: IOneSignalNotifications;
 	Session: IOneSignalSession;
@@ -263,7 +264,7 @@ interface IOneSignalOneSignal {
 	setConsentGiven(consent: boolean): Promise<void>;
 	setConsentRequired(requiresConsent: boolean): Promise<void>;
 }
-interface IOneSignalNotifications {
+export interface IOneSignalNotifications {
 	permissionNative: NotificationPermission;
 	permission: boolean;
 	setDefaultUrl(url: string): Promise<void>;
@@ -273,7 +274,7 @@ interface IOneSignalNotifications {
 	addEventListener<K extends NotificationEventName>(event: K, listener: (obj: NotificationEventTypeMap[K]) => void): void;
 	removeEventListener<K extends NotificationEventName>(event: K, listener: (obj: NotificationEventTypeMap[K]) => void): void;
 }
-interface IOneSignalSlidedown {
+export interface IOneSignalSlidedown {
 	promptPush(options?: AutoPromptOptions): Promise<void>;
 	promptPushCategories(options?: AutoPromptOptions): Promise<void>;
 	promptSms(options?: AutoPromptOptions): Promise<void>;
@@ -282,14 +283,14 @@ interface IOneSignalSlidedown {
 	addEventListener(event: SlidedownEventName, listener: (wasShown: boolean) => void): void;
 	removeEventListener(event: SlidedownEventName, listener: (wasShown: boolean) => void): void;
 }
-interface IOneSignalDebug {
+export interface IOneSignalDebug {
 	setLogLevel(logLevel: string): void;
 }
-interface IOneSignalSession {
+export interface IOneSignalSession {
 	sendOutcome(outcomeName: string, outcomeWeight?: number): Promise<void>;
 	sendUniqueOutcome(outcomeName: string): Promise<void>;
 }
-interface IOneSignalUser {
+export interface IOneSignalUser {
 	PushSubscription: IOneSignalPushSubscription;
 	addAlias(label: string, id: string): void;
 	addAliases(aliases: { [key: string]: string }): void;
@@ -304,7 +305,7 @@ interface IOneSignalUser {
 	removeTag(key: string): void;
 	removeTags(keys: string[]): void;
 }
-interface IOneSignalPushSubscription {
+export interface IOneSignalPushSubscription {
 	id: string | null | undefined;
 	token: string | null | undefined;
 	optedIn: boolean | undefined;


### PR DESCRIPTION
### Overview
This pull request contains the exporting of the type definitions within the index.ts file.

### Benefits
- Developers can now import types directly, avoiding the use of complex and less intuitive syntax to access type definitions.
- Easier access to type definitions encourages proper typing, which can lead to more maintainable and less error-prone code.

### Related open issues
- [(https://github.com/OneSignal/react-onesignal/issues/108)](https://github.com/OneSignal/react-onesignal/issues/108)