### PR TITLE
Provide onesignalId within the user namespace

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -740,8 +740,8 @@ const UserNamespace: IOneSignalUser = {
 	addTags: userAddTags,
 	removeTag: userRemoveTag,
 	removeTags: userRemoveTags,
-	PushSubscription: PushSubscriptionNamespace,
-  onesignalId: window.OneSignal?.User?.onesignalId
+  get onesignalId(): string | null | undefined { return window.OneSignal?.User?.onesignalId },
+	PushSubscription: PushSubscriptionNamespace
 };
 
 const SessionNamespace: IOneSignalSession = {

--- a/index.ts
+++ b/index.ts
@@ -303,7 +303,9 @@ interface IOneSignalUser {
 	addTags(tags: { [key: string]: string }): void;
 	removeTag(key: string): void;
 	removeTags(keys: string[]): void;
+  onesignalId?: string;
 }
+
 interface IOneSignalPushSubscription {
 	id: string | null | undefined;
 	token: string | null | undefined;
@@ -739,6 +741,7 @@ const UserNamespace: IOneSignalUser = {
 	removeTag: userRemoveTag,
 	removeTags: userRemoveTags,
 	PushSubscription: PushSubscriptionNamespace,
+  onesignalId: window.OneSignal?.User?.onesignalId
 };
 
 const SessionNamespace: IOneSignalSession = {


### PR DESCRIPTION
### Overview
This pull request provides a getter function for onesignalId in the User namespace

### Benefits
-  Provides a straightforward method to retrieve the `onesignalId`, enhancing code readability and maintainability.
- Supports implementations where direct access to `onesignalId` is crucial, such as for personalized push notifications or user tracking.
- Eliminates the need for developers to implement custom solutions for accessing the `onesignalId`, thereby reducing potential bugs and code redundancy.
