### PR TITLE
Exclude tests from production package

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,6 @@
-import OneSignal from './index';
+import OneSignal from '../index';
+
+declare const global: typeof globalThis;
 
 const originalDocument = global.document;
 const documentSpy = vi.spyOn(global, 'document', 'get');

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,8 @@
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
-    "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "skipLibCheck": true
   },
-  "include": ["index.ts", "index.test.ts"],
+  "include": ["index.ts"],
   "exclude": ["node_modules", "build", "dist", "example", "rollup.config.js"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
+    typecheck: {
+      tsconfig: "./tests/tsconfig.json",
+    },
+    environment: "jsdom",
     globals: true,
   },
 });


### PR DESCRIPTION
Running `npm run build` fails with `index.test.ts:3:26 - error TS2304: Cannot find name 'global'.` as test files are included in the build package. This PR splits up build and test environments. 